### PR TITLE
Adiciona endpoint para nível de escrita consolidado em português

### DIFF
--- a/SME.Pedagogico.Gestao.Data/Business/PollPortugues.cs
+++ b/SME.Pedagogico.Gestao.Data/Business/PollPortugues.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using SME.Pedagogico.Gestao.Data.DTO.Matematica.Relatorio;
+using Npgsql;
 
 namespace SME.Pedagogico.Gestao.Data.Business
 {
@@ -1302,6 +1303,42 @@ namespace SME.Pedagogico.Gestao.Data.Business
                     Leitura3Bim = resultado.reading3B,
                     Leitura4Bim = resultado.reading4B
                 };
+            }
+        }
+
+        public async Task<IEnumerable<ResultadoNivelEscritaPorAlunoEmPortuguesDTO>> ObterConsolidadoNivelEscritaPorAlunoEmPortugues()
+        {
+            const string sql = @"
+                SELECT
+                    pp.""dreCodeEol"" as dreCodigo,
+                    pp.""schoolCodeEol"" as ueCodigo,
+                    pp.""schoolYear"" as anoLetivo,
+                    unpivoted.nivelEscrita,
+                    unpivoted.periodo,
+                    COUNT(*) AS quantidade
+                FROM
+                    ""PortuguesePolls"" pp
+                CROSS JOIN LATERAL (
+                    VALUES
+                        (1, pp.""writing1B""),
+                        (2, pp.""writing2B""),
+                        (3, pp.""writing3B""),
+                        (4, pp.""writing4B"")
+                ) AS unpivoted(periodo, nivelEscrita)
+                WHERE
+                    unpivoted.nivelEscrita in ('A', 'PS', 'SA', 'SCV', 'SSV')  -- Parâmetro para segurança
+                GROUP BY
+                    pp.""dreCodeEol"",
+                    pp.""schoolCodeEol"",
+                    pp.""schoolYear"",
+                    unpivoted.nivelEscrita,
+                    unpivoted.periodo
+                HAVING 
+                    unpivoted.nivelEscrita IS NOT NULL; -- Garante que apenas períodos preenchidos sejam contados";
+
+            using (var conexao = new NpgsqlConnection(Environment.GetEnvironmentVariable("sondagemConnection")))
+            {
+                return await conexao.QueryAsync<ResultadoNivelEscritaPorAlunoEmPortuguesDTO>(sql);
             }
         }
     }

--- a/SME.Pedagogico.Gestao.Data/DTO/Portugues/ResultadoNivelEscritaPorAlunoEmPortuguesDTO.cs
+++ b/SME.Pedagogico.Gestao.Data/DTO/Portugues/ResultadoNivelEscritaPorAlunoEmPortuguesDTO.cs
@@ -1,0 +1,12 @@
+﻿namespace SME.Pedagogico.Gestao.Data.DTO.Portugues
+{
+    public class ResultadoNivelEscritaPorAlunoEmPortuguesDTO
+    {
+        public string DreCodigo { get; set; }
+        public string UeCodigo { get; set; }
+        public string AnoLetivo { get; set; }
+        public string NivelEscrita { get; set; }
+        public short Periodo { get; set; }
+        public int QuantidadeAlunos { get; set; }
+    }
+}

--- a/SME.Pedagogico.Gestao.WebApp/Controllers/SondagemPortuguesController.cs
+++ b/SME.Pedagogico.Gestao.WebApp/Controllers/SondagemPortuguesController.cs
@@ -6,6 +6,7 @@ using SME.Pedagogico.Gestao.Data.DTO;
 using SME.Pedagogico.Gestao.Data.DTO.Portugues;
 using SME.Pedagogico.Gestao.WebApp.Models.ClassRoom;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using EnumModels = SME.Pedagogico.Gestao.Models.Enums;
 
@@ -148,6 +149,14 @@ namespace SME.Pedagogico.Gestao.WebApp.Controllers
             var sondagemAutoralBll = new PollPortuguese(_config);
 
             return Ok(await sondagemAutoralBll.ListaSequenciaOrdensSalva(filtrarListagemDto));
+        }
+
+        [HttpGet("consolidado-nivel-escrita")]
+        public async Task<IActionResult> ObterConsolidadoNivelEscrita()
+        {
+            var sondagemAutoralBll = new PollPortuguese(_config);
+            var consolidado = await sondagemAutoralBll.ObterConsolidadoNivelEscritaPorAlunoEmPortugues();
+            return consolidado == null || consolidado.Count() == 0 ? NoContent() : (IActionResult)Ok(consolidado);
         }
     }
 }


### PR DESCRIPTION
Apresenta um novo DTO e um método de negócios para recuperar dados consolidados do nível de escrita por aluno em português. Adiciona o endpoint ObterConsolidadoNivelEscrita ao SondagemPortuguesController para expor esses dados via API.