### PR TITLE
Renomeia coluna SQL e atualiza rota Sondagem controller

### DIFF
--- a/SME.Pedagogico.Gestao.Data/Business/PollPortugues.cs
+++ b/SME.Pedagogico.Gestao.Data/Business/PollPortugues.cs
@@ -1315,7 +1315,7 @@ namespace SME.Pedagogico.Gestao.Data.Business
                     pp.""schoolYear"" as anoLetivo,
                     unpivoted.nivelEscrita,
                     unpivoted.periodo,
-                    COUNT(*) AS quantidade
+                    COUNT(*) AS quantidadeAlunos
                 FROM
                     ""PortuguesePolls"" pp
                 CROSS JOIN LATERAL (

--- a/SME.Pedagogico.Gestao.WebApp/Controllers/SondagemPortuguesController.cs
+++ b/SME.Pedagogico.Gestao.WebApp/Controllers/SondagemPortuguesController.cs
@@ -151,7 +151,7 @@ namespace SME.Pedagogico.Gestao.WebApp.Controllers
             return Ok(await sondagemAutoralBll.ListaSequenciaOrdensSalva(filtrarListagemDto));
         }
 
-        [HttpGet("consolidado-nivel-escrita")]
+        [HttpGet()]
         public async Task<IActionResult> ObterConsolidadoNivelEscrita()
         {
             var sondagemAutoralBll = new PollPortuguese(_config);


### PR DESCRIPTION
Renomeia a coluna de resultados SQL de "quantidade" para "quantidadeAlunos" em PollPortugues.cs. Também remove a rota explícita do endpoint "ObterConsolidadoNivelEscrita" em SondagemPortuguesController.